### PR TITLE
Change BTC feerate's lowpriority duration to 10 hours.

### DIFF
--- a/feeratekit/src/main/kotlin/io/horizontalsystems/feeratekit/model/FeeRate.kt
+++ b/feeratekit/src/main/kotlin/io/horizontalsystems/feeratekit/model/FeeRate.kt
@@ -40,7 +40,7 @@ enum class Coin(
             BITCOIN -> FeeRate(
                     coin = this,
                     lowPriority = 20,
-                    lowPriorityDuration = 1440 * 60,
+                    lowPriorityDuration = 600 * 60, // 10 hours
                     mediumPriority = 40,
                     mediumPriorityDuration = 120 * 60,
                     highPriority = 80,


### PR DESCRIPTION
- Change BTC feerate's lowpriority duration from 24 h. to 10 hours.